### PR TITLE
Fix PHP 8.1 compatibility

### DIFF
--- a/lib/Job/Processor/StandardProcessor.php
+++ b/lib/Job/Processor/StandardProcessor.php
@@ -309,7 +309,7 @@ class StandardProcessor implements IProcessor {
      * @throws \Exception
      */
     private function waitForChildProcess($pid): int {
-        $status = "Forked $pid at " . strftime('%F %T');
+        $status = "Forked $pid at " . date('Y-m-d H:i:s');
         Process::setTitle($status);
         Log::info($status);
 

--- a/lib/Job/RunningJob.php
+++ b/lib/Job/RunningJob.php
@@ -150,7 +150,7 @@ class RunningJob {
      */
     private function createFailContext(\Throwable $t, $retryText = 'no retry') {
         return [
-            'start_time' => date('Y-m-d\TH:i:s.uP', $this->startTime),
+            'start_time' => date('Y-m-d\TH:i:s.uP', (int)$this->startTime),
             'payload' => $this->job->toArray(),
             'exception' => $t,
             'retried_by' => $retryText
@@ -184,6 +184,6 @@ class RunningJob {
             $duration = 0;
         }
 
-        JobStats::getInstance()->reportDuration($this, $duration);
+        JobStats::getInstance()->reportDuration($this, (int)$duration);
     }
 }

--- a/lib/Redis.php
+++ b/lib/Redis.php
@@ -418,7 +418,7 @@ class Redis {
         ]);
         $this->close();
 
-        usleep($wait * 1000000);
+        usleep((int)($wait * 1000000));
 
         try {
             return $this->driver->__call($name, $args);


### PR DESCRIPTION
Removed use of [deprecated strftime()](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.date)
Removed [deprecated implicit casting of float to int](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.implicit-float-conversion)

Close #25